### PR TITLE
make compatible with hsl-experimental dev-master

### DIFF
--- a/src/TestLib/StringInput.hack
+++ b/src/TestLib/StringInput.hack
@@ -39,7 +39,8 @@ final class StringInput implements IO\ReadHandle, IO\UserspaceHandle {
 
   public async function readAsync(
     ?int $max_bytes = null,
-    ?float $_timeout_seconds = null,
+    // seconds_or_ns to support hsl-experimental <= 4.50.1 as well as newer
+    ?num $_timeout_seconds_or_ns = null,
   ): Awaitable<string> {
     invariant(
       $max_bytes === null || $max_bytes >= 0,
@@ -57,7 +58,12 @@ final class StringInput implements IO\ReadHandle, IO\UserspaceHandle {
     return Str\slice($buf, 0, $max_bytes);
   }
 
+  // read() alias for hsl-experimental <= 4.50.1
   public function rawReadBlocking(?int $max_bytes = null): string {
+    return $this->read($max_bytes);
+  }
+
+  public function read(?int $max_bytes = null): string {
     if ($max_bytes === null) {
       $max_bytes = Str\length($this->buffer);
     }

--- a/tests/TestCLITrait.hack
+++ b/tests/TestCLITrait.hack
@@ -65,7 +65,9 @@ trait TestCLITrait {
   }
 
   private async function replAsync(): Awaitable<int> {
-    $in = $this->getStdin();
+    // TODO: Replace with a buffered line reader when new hsl-experimental is
+    // released.
+    $in = $this->getStdin() as TestLib\StringInput;
     $out = $this->getStdout();
     $err = $this->getStderr();
     while (!$in->isEndOfFile()) {


### PR DESCRIPTION
I don't know if anyone uses this TestLib and cares about compatibility with different versions of hsl-experimental, but it seems easy enough to support both the current version as well as future versions (with the new read API), so we might as well?

This should unbreak https://travis-ci.org/hhvm/hsl without breaking anything else.