### PR TITLE
Update tests for HSL IO v0.2

### DIFF
--- a/.travis.sh
+++ b/.travis.sh
@@ -15,5 +15,5 @@ hh_client
 
 vendor/bin/hacktest tests/
 if !(hhvm --version | grep -q -- -dev); then
-  vendor/bin/hhast-lint
+# TEMPORARY: circular dependency for HSL-IO v0.2 upgrade  vendor/bin/hhast-lint
 fi

--- a/.travis.sh
+++ b/.travis.sh
@@ -14,6 +14,7 @@ composer install
 hh_client
 
 vendor/bin/hacktest tests/
-if !(hhvm --version | grep -q -- -dev); then
-# TEMPORARY: circular dependency for HSL-IO v0.2 upgrade  vendor/bin/hhast-lint
-fi
+# TEMPORARY: circular dependency for HSL-IO v0.2 upgrade
+#if !(hhvm --version | grep -q -- -dev); then
+#  vendor/bin/hhast-lint
+#fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ sudo: required
 language: generic
 services: docker
 env:
-- HHVM_VERSION=4.58-latest
+- HHVM_VERSION=4.60-latest
 - HHVM_VERSION=latest
 - HHVM_VERSION=nightly
 install:

--- a/composer.json
+++ b/composer.json
@@ -7,7 +7,7 @@
     }
   },
   "require": {
-    "hhvm": "^4.58",
+    "hhvm": "^4.60",
     "hhvm/hsl": "^4.0",
     "hhvm/type-assert": "^4.0",
     "hhvm/hsl-experimental": "^4.58.0rc1",

--- a/tests/InteractivityTest.hack
+++ b/tests/InteractivityTest.hack
@@ -14,7 +14,12 @@ use function Facebook\FBExpect\expect;
 
 final class InteractivityTest extends TestCase {
   private function getCLI(
-  ): (TestCLIWithoutArguments, IO\MemoryHandle, IO\MemoryHandle, IO\MemoryHandle) {
+  ): (
+    TestCLIWithoutArguments,
+    IO\MemoryHandle,
+    IO\MemoryHandle,
+    IO\MemoryHandle,
+  ) {
     $stdin = new IO\MemoryHandle();
     $stdout = new IO\MemoryHandle();
     $stderr = new IO\MemoryHandle();
@@ -30,31 +35,53 @@ final class InteractivityTest extends TestCase {
     $in->close();
     $ret = await $cli->mainAsync();
     expect($ret)->toBeSame(0);
-    expect($out->getBuffer())->toBeSame('');
+    expect($out->getBuffer())->toBeSame('> ');
     expect($err->getBuffer())->toBeSame('');
   }
 
   public async function testSingleCommandBeforeStart(): Awaitable<void> {
-    list($cli, $in, $out, $err) = $this->getCLI();
-    $in->appendToBuffer("echo hello, world\n");
-    $in->close();
-    $ret = await $cli->mainAsync();
-    expect($err->getBuffer())->toBeSame('');
-    expect($out->getBuffer())->toBeSame("> hello, world\n");
-    expect($ret)->toBeSame(0);
+    // Don't use the MemoryHandle because reading from a closed handle
+    // doesn't make sense - a pipe is both necessary, and a better
+    // representation of 'echo foo | myprog'
+    list($in_r, $in) = IO\pipe();
+    $out = new IO\MemoryHandle();
+    $err = new IO\MemoryHandle();
+    $cli = new TestCLIWithoutArguments(
+      vec[__FILE__, '--interactive'],
+      new Terminal($in_r, $out, $err),
+    );
+    concurrent {
+      $ret = await $cli->mainAsync();
+      await async {
+        await $in->writeAllAsync("echo hello, world\n");
+        $in->close();
+      };
+    }
+    $in_r->close();
+    expect($err->getBuffer())->toEqual('');
+    expect($out->getBuffer())->toEqual("> hello, world\n> ");
+    expect($ret)->toEqual(0);
   }
 
   public async function testSingleCommandAfterStart(): Awaitable<void> {
-    list($cli, $in, $out, $err) = $this->getCLI();
+    list($in_r, $in) = IO\pipe();
+    $out = new IO\MemoryHandle();
+    $err = new IO\MemoryHandle();
+    $cli = new TestCLIWithoutArguments(
+      vec[__FILE__, '--interactive'],
+      new Terminal($in_r, $out, $err),
+    );
     concurrent {
       $ret = await $cli->mainAsync();
       await async {
         await \HH\Asio\later();
         expect($out->getBuffer())->toBeSame('> ');
         $out->reset();
-        $in->appendToBuffer("exit 123\n");
+        await $in->writeAllAsync("exit 123\n");
+        $in->close();
       };
     }
+    $in_r->close();
     expect($ret)->toBeSame(123);
     expect($out->getBuffer())->toBeSame('');
   }
@@ -64,7 +91,6 @@ final class InteractivityTest extends TestCase {
     $in->appendToBuffer("echo hello, world\n");
     $in->appendToBuffer("echo foo bar\n");
     $in->appendToBuffer("exit 123\n");
-    $in->close();
     $ret = await $cli->mainAsync();
     expect($err->getBuffer())->toBeSame('');
     expect($out->getBuffer())->toBeSame("> hello, world\n> foo bar\n> ");
@@ -72,7 +98,13 @@ final class InteractivityTest extends TestCase {
   }
 
   public async function testMultipleCommandsSequentially(): Awaitable<void> {
-    list($cli, $in, $out, $err) = $this->getCLI();
+    list($in_r, $in) = IO\pipe();
+    $out = new IO\MemoryHandle();
+    $err = new IO\MemoryHandle();
+    $cli = new TestCLIWithoutArguments(
+      vec[__FILE__, '--interactive'],
+      new Terminal($in_r, $out, $err),
+    );
     concurrent {
       $ret = await $cli->mainAsync();
       await async {
@@ -80,18 +112,19 @@ final class InteractivityTest extends TestCase {
         expect($out->getBuffer())->toBeSame('> ');
         $out->reset();
 
-        $in->appendToBuffer("echo foo bar\n");
+        await $in->writeAllAsync("echo foo bar\n");
         await \HH\Asio\later();
 
         expect($out->getBuffer())->toBeSame("foo bar\n> ");
         $out->reset();
 
-        $in->appendToBuffer("echo herp derp\n");
+        await $in->writeAllAsync("echo herp derp\n");
         await \HH\Asio\later();
         expect($out->getBuffer())->toBeSame("herp derp\n> ");
 
         $out->reset();
-        $in->appendToBuffer("exit 42\n");
+        await $in->writeAllAsync("exit 42\n");
+        $in->close();
       };
     }
     expect($ret)->toBeSame(42);

--- a/tests/TestCLITrait.hack
+++ b/tests/TestCLITrait.hack
@@ -68,8 +68,8 @@ trait TestCLITrait {
     $in = $this->getStdin();
     $out = $this->getStdout();
     $err = $this->getStderr();
+    await $out->writeAsync('> ');
     foreach((new IO\BufferedReader($in))->linesIterator() await as $line) {
-      await $out->writeAsync('> ');
       $sep = Str\search($line, ' ');
       if ($sep === null) {
         await $err->writeAsync("Usage: (exit <code>|echo foo bar ....\n");
@@ -92,6 +92,7 @@ trait TestCLITrait {
           await $err->writeAsync("Invalid command\n");
           return 1;
       }
+      await $out->writeAsync('> ');
     }
     return 0;
   }


### PR DESCRIPTION
I think the logic being tested was bad; there are two classes of issues
here:

- `IO\MemoryHandle` works like a read-write file. `TestLib\StringInput`
  was... unique. Use pipes where we need funky stuff. In particular, if
  it's closed, it can't be read from.

- Checking `isEndOfFile()` before echoing the `> ` prompt was a bug and
  undefined behavior really - consistently prompt before attempting to get
  input