### PR TITLE
Require hhvm 4.128 and support autoloading with ext_watchman

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,3 +1,4 @@
 tests/ export-ignore
 .hhconfig export-ignore
+.hhvmconfig.hdf export-ignore
 *.hack linguist-language=Hack

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -13,7 +13,7 @@ jobs:
       matrix:
         os: [ ubuntu, macos ]
         hhvm:
-          - '4.102'
+          - '4.128'
           - latest
           - nightly
     runs-on: ${{matrix.os}}-latest

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 vendor/
+.var/
 *.swp
 *.swo
 composer.lock

--- a/.hhvmconfig.hdf
+++ b/.hhvmconfig.hdf
@@ -1,0 +1,3 @@
+Autoload {
+  Query = {"expression": ["allof", ["type", "f"], ["suffix", ["anyof", "hack", "php"]], ["not",["anyof",["dirname",".var"],["dirname",".git"]]]]}
+}

--- a/composer.json
+++ b/composer.json
@@ -8,11 +8,8 @@
     }
   },
   "require": {
-    "hhvm": "^4.102",
-    "hhvm/hsl": "^4.0",
-    "hhvm/type-assert": "^4.0",
-    "hhvm/hsl-experimental": "^4.58.0rc1",
-    "hhvm/hsl-io": "^0.3.0"
+    "hhvm": "^4.128",
+    "hhvm/type-assert": "^4.0"
   },
   "require-dev": {
     "facebook/fbexpect": "^2.6.1",

--- a/composer.json
+++ b/composer.json
@@ -16,5 +16,10 @@
     "hhvm/hhvm-autoload": "^3.1.0",
     "hhvm/hacktest": "^2.2.0rc1",
     "hhvm/hhast": "^4.88.1"
+  },
+  "config": {
+    "allow-plugins": {
+      "hhvm/hhvm-autoload": true
+    }
   }
 }

--- a/hh_autoload.json
+++ b/hh_autoload.json
@@ -1,5 +1,6 @@
 {
     "roots": [ "src/" ],
     "devRoots": [ "tests/" ],
-    "devFailureHandler": "Facebook\\AutoloadMap\\HHClientFallbackHandler"
+    "devFailureHandler": "Facebook\\AutoloadMap\\HHClientFallbackHandler",
+    "useFactsIfAvailable": true
 }


### PR DESCRIPTION
The hsl is always built-in.
ext_watchman and HH\Facts are always available.
varray eq vec and darray eq dict is always true.