### PR TITLE
Fix hack syntax in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ use type Facebook\CLILib\CLIBase;
 final class MyCLI extends CLIBase {
   <<__Override>>
   public async function mainAsync(): Awaitable<int> {
-    $this->getStdout()->write("Hello, world!');
+    $this->getStdout()->write("Hello, world!");
     return 0;
   }
 }


### PR DESCRIPTION
Wrong ending quote is causing invalid syntax highlighting.

https://github.com/hhvm/hh-clilib/blob/main/README.md?plain=1#L3

**Before**
![Screen Shot 2022-08-18 at 2 00 08 PM](https://user-images.githubusercontent.com/35247622/185493869-69590b90-b510-4223-82d9-09605852d4b8.png)

**After**

![Screen Shot 2022-08-18 at 2 04 35 PM](https://user-images.githubusercontent.com/35247622/185494700-4c8aa513-74b4-4bb0-9cbe-ce8ac1de9c73.png)
